### PR TITLE
PF-273: Use analytics token

### DIFF
--- a/src/app/analytics/dashboard/dashboard.component.spec.ts
+++ b/src/app/analytics/dashboard/dashboard.component.spec.ts
@@ -1,13 +1,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DashboardComponent } from './dashboard.component';
+import { AuthService } from '../../auth/auth.service';
+import { of } from 'rxjs';
+import { LOCALE_ID } from '@angular/core';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
 
   beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService', ['getAnalyticsToken']);
+    authService.getAnalyticsToken.and.returnValue(of('token'));
+
     await TestBed.configureTestingModule({
       imports: [DashboardComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: LOCALE_ID, useValue: 'es-CO' },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -213,4 +213,18 @@ describe('AuthService', () => {
 
     expect(service.isUnassigned()).toBe(true);
   });
+
+  it('getAnalyticsToken should return token', () => {
+    initComponent();
+
+    const mockToken = faker.string.alphanumeric(10);
+
+    service.getAnalyticsToken().subscribe(result => {
+      expect(result).toBe(mockToken);
+    });
+
+    const req = httpTestingController.expectOne(`${environment.apiUrl}/auth/employee/analytics`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ token: mockToken });
+  });
 });

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -129,6 +129,14 @@ export class AuthService {
     );
   }
 
+  getAnalyticsToken(): Observable<string> {
+    return this.http.post<TokenResponse>(`${this.apiUrl}/auth/employee/analytics`, {}).pipe(
+      map(response => {
+        return response.token;
+      }),
+    );
+  }
+
   getToken(): string | null {
     return localStorage.getItem('token');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated an authentication token retrieval process in the `DashboardComponent` for enhanced analytics functionality.
	- Added a new method in `AuthService` to fetch an analytics token via an HTTP request.

- **Bug Fixes**
	- Improved test coverage for the `getAnalyticsToken` method in `AuthService`.

- **Tests**
	- Enhanced testing framework for the `DashboardComponent` to utilize a mocked `AuthService`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->